### PR TITLE
Add drawio_args option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0: ease containerisation
+
+* New `drawio_args` option allows passing additional args to the Draw.io CLI
+
 ## 0.5.0: support MkDocs 1.1
 
 * Make dependency upgrades a little easier

--- a/README.md
+++ b/README.md
@@ -60,6 +60,39 @@ If you're working with multi-page documents, append the index of the page as an 
 
 The plugin will export the diagram to the `format` specified in your configuration and will rewrite the `<img>` tag in the generated page to match. To speed up your documentation rebuilds, the generated output will be placed into `cache_dir` and then copied to the desired destination. The cached images will only be updated if the source diagram's modification date is newer than the cached export.
 
+### Headless usage
+
+In addition to the above, if you're running in a headless environment (e.g. in integration, or inside a Docker container), you may need to ensure a display server is running and that the necessary dependencies are installed.
+
+On Debian and Ubuntu, the following should install the dependencies:
+
+```console
+sudo apt install libasound2 xvfb
+```
+
+To run MkDocs with an automatically assigned X display, wrap the command as follows:
+
+```console
+xvfb-run -a mkdocs build
+```
+
+### Running without the sandbox
+
+If you're seeing messages like the following it's likely that you're running MkDocs as root:
+
+```text
+[22:0418/231827.169035:FATAL:electron_main_delegate.cc(211)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
+```
+
+If possible, consider running MkDocs as a non-privileged user. Depending on the circumstances (e.g. running within an unprivilegedcontainer) it may be appropriate to disable the Chrome sandbox by adding the following option to `mkdocs.yml`:
+
+```yaml
+plugins:
+    - drawio-exporter:
+        drawio_args:
+            - --no-sandbox
+```
+
 ## Hacking
 
 To get completion working in your editor, set up a virtual environment in the root of this repository and install MkDocs:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ plugins:
         # We'll look for it on your system's PATH, then default installation
         # paths. If we can't find it we'll warn you.
         drawio_executable: null
+        # Additional Draw.io CLI args
+        drawio_args: []
         # Output format (see draw.io --help | grep format)
         format: svg
         # Glob pattern for matching source files

--- a/mkdocsdrawioexporter/exporter.py
+++ b/mkdocsdrawioexporter/exporter.py
@@ -189,13 +189,14 @@ class DrawIoExporter:
         """
         return [f for f in files if not f.abs_src_path.startswith(cache_dir)]
 
-    def ensure_file_cached(self, source, source_rel, page_index, drawio_executable, cache_dir, format):
+    def ensure_file_cached(self, source, source_rel, page_index, drawio_executable, drawio_args, cache_dir, format):
         """Ensure cached copy of output exists.
 
         :param str source: Source path, absolute.
         :param str source_rel: Source path, relative to docs directory.
         :param int page_index: Page index, numbered from zero.
         :param str drawio_executable: Path to the configured Draw.io executable.
+        :param list(str) drawio_args: Additional arguments to append to the Draw.io export command.
         :param str cache_dir: Export cache directory.
         :param str format: Desired export format.
         :return str: Cached export filename.
@@ -209,7 +210,9 @@ class DrawIoExporter:
             self.log.debug('Source file appears unchanged; using cached copy from "{}"'.format(cache_filename))
         else:
             self.log.debug('Exporting "{}" to "{}"'.format(source, cache_filename))
-            exit_status = self.export_file(source, page_index, cache_filename, drawio_executable, format)
+            exit_status = self.export_file(
+                    source, page_index, cache_filename,
+                    drawio_executable, drawio_args, format)
             if exit_status != 0:
                 self.log.error('Export failed with exit status {}'.format(exit_status))
                 return
@@ -238,13 +241,14 @@ class DrawIoExporter:
         return os.path.exists(cache_filename) \
                 and os.path.getmtime(cache_filename) >= os.path.getmtime(source)
 
-    def export_file(self, source, page_index, dest, drawio_executable, format):
+    def export_file(self, source, page_index, dest, drawio_executable, drawio_args, format):
         """Export an individual file.
 
         :param str source: Source path, absolute.
         :param int page_index: Page index, numbered from zero.
         :param str dest: Destination path, within cache.
         :param str drawio_executable: Path to the configured Draw.io executable.
+        :param list(str) drawio_args: Additional arguments to append to the Draw.io export command.
         :param str format: Desired export format.
         :return int: The Draw.io exit status.
         """
@@ -255,6 +259,7 @@ class DrawIoExporter:
             '--output', dest,
             '--format', format,
         ]
+        cmd += drawio_args
 
         try:
             self.log.debug('Using export command {}'.format(cmd))

--- a/mkdocsdrawioexporter/plugin.py
+++ b/mkdocsdrawioexporter/plugin.py
@@ -24,6 +24,7 @@ class DrawIoExporterPlugin(mkdocs.plugins.BasePlugin):
     config_scheme = (
         ('cache_dir', config_options.Type(str)),
         ('drawio_executable', config_options.Type(str)),
+        ('drawio_args', config_options.Type(list, default=[])),
         ('format', config_options.Type(str, default='svg')),
         ('image_re', config_options.Type(str, default='(<img[^>]+src=")([^">]+)("\s*\/?>)')),
         ('sources', config_options.Type(str, default='*.drawio')),
@@ -46,8 +47,9 @@ class DrawIoExporterPlugin(mkdocs.plugins.BasePlugin):
         os.makedirs(self.config['cache_dir'], exist_ok=True)
         self.image_re = re.compile(self.config['image_re'])
 
-        log.debug('Using Draw.io executable "{}", cache directory "{}" and image regular expression "{}"'.format(
-                self.config['drawio_executable'], self.config['cache_dir'], self.config['image_re']))
+        log.debug('Using Draw.io executable "{}", arguments {}, cache directory "{}" and image regular expression "{}"'.format(
+                self.config['drawio_executable'], self.config['drawio_args'],
+                self.config['cache_dir'], self.config['image_re']))
 
     def on_post_page(self, output_content, page, **kwargs):
         output_content, content_sources = self.exporter.rewrite_image_embeds(
@@ -78,8 +80,8 @@ class DrawIoExporterPlugin(mkdocs.plugins.BasePlugin):
             abs_dest_path = os.path.join(config['site_dir'], dest_rel_path)
             cache_filename = self.exporter.ensure_file_cached(
                     abs_src_path, source.source_rel, source.page_index,
-                    self.config['drawio_executable'], self.config['cache_dir'],
-                    self.config['format'])
+                    self.config['drawio_executable'], self.config['drawio_args'],
+                    self.config['cache_dir'], self.config['format'])
 
             try:
                 copy_file(cache_filename, abs_dest_path)


### PR DESCRIPTION
This allows easily passing the `--no-sandbox` option to the Draw.io executable during export, thus making it much easier to run in containerised environments.

Fixes #12