### PR TITLE
Add link_css option

### DIFF
--- a/mkdocs_drawio_exporter/exporter.py
+++ b/mkdocs_drawio_exporter/exporter.py
@@ -248,6 +248,34 @@ class DrawIoExporter:
                     'embed_format', config['embed_format'],
                     'cannot inline content of non-SVG format')
 
+    def set_css_classes(self, svg_content, prefix="--drawio-color"):
+        """Rewrite SVG styles to use CSS variables.
+        Will replace all `stroke` and `fill` attributes with CSS variables
+        such as `var(--drawio-color-ffffff)`.
+
+        :param str svg_content: SVG content.
+        :param str prefix: CSS variable prefix.
+
+        :return str: SVG content with styles rewritten.
+        """
+        pattern = re.compile(
+            (r'(fill|stroke)\s*='
+             r'\s*\"(\#[A-Fa-f0-9]+|'
+             r'rgb\([0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\))\"'))
+
+        def apply_style(match):
+            fill = match.group(2)
+            if fill.startswith("#"):
+                hexcolor = fill[1:]
+            else:
+                r, g, b = [
+                    int(x) for x in
+                    re.match(r"rgb\((\d+),\s*(\d+),\s*(\d+)\)", fill).groups()]
+                hexcolor = f"{r:02x}{g:02x}{b:02x}"
+            return f'{match.group(1)}="{f"var({prefix}-{hexcolor})"}"'
+
+        return pattern.sub(apply_style, svg_content)
+
     def rewrite_image_embeds(self, page_dest_path, output_content, config: Configuration):
         """Rewrite image embeds.
 
@@ -289,8 +317,11 @@ class DrawIoExporter:
                         self.log.error(f'Export failed with exit status {exit_status}; skipping rewrite')
                         return match.group(0)
 
-                    with open(img_path, "r") as f:
+                    with open(img_path, "r", encoding="utf-8") as f:
                         content = f.read()
+
+                    if config["link_css"]:
+                        content = self.set_css_classes(content)
 
                 return config["embed_format"].format(
                         img_open=match.group(1), img_close=match.group(3),

--- a/mkdocs_drawio_exporter/plugin.py
+++ b/mkdocs_drawio_exporter/plugin.py
@@ -27,6 +27,7 @@ class DrawIoExporterPlugin(mkdocs.plugins.BasePlugin):
         ('format', config_options.Type(str, default='svg')),
         ('embed_format', config_options.Type(str, default='{img_open}{img_src}{img_close}')),
         ('sources', config_options.Type(str, default='*.drawio')),
+        ('link_css', config_options.Type(bool, default=False)),
     )
 
     exporter = None


### PR DESCRIPTION
I was disappointed to find that the colors in Draw.io do not match the MkDocs theme. Unfortunately, Draw.io does not support applying CSS styles directly; instead, it uses a set of predefined colors. These colors are applied to SVG elements using the `stroke=` or `fill=` attributes.

The idea is to leverage the `embed_format: '{content}'` option to replace `fill` and `stroke` attributes with CSS variables.

![image](https://github.com/LukeCarrier/mkdocs-drawio-exporter/assets/52489316/b2844002-3cba-4a16-b2c3-943851a2dc13)

![image](https://github.com/LukeCarrier/mkdocs-drawio-exporter/assets/52489316/6ccf0633-d941-4c9c-ac0e-81d0dff0fbe2)

In this example, I used the following `mkdocs.yml`:

```yml
site_name: Draw Exporter with CSS
plugins:
  - drawio-exporter:
      embed_format: '{content}'
      link_css: true
theme:
  name: material
  palette:
    - scheme: default
      toggle:
        icon: material/toggle-switch-off-outline
        name: Switch to dark mode
    - scheme: slate
      toggle:
        icon: material/toggle-switch
        name: Switch to light mode

extra_css:
  - style.css
```

The `style.css` is:

```css
:root {
    --drawio-color-ffffff: #000000;
    --drawio-color-f5f5f5: #e9b3b3;
    --drawio-color-dae8fc: #9bbbe7;
    --drawio-color-d5e8d4: #75c770;
    --drawio-color-ffe6cc: #cc9e6d;
    --drawio-color-fff2cc: #dabd66;
    --drawio-color-f8cecc: #b95c57;
    --drawio-color-e1d5e7: #8c49ad;
}

[data-md-color-scheme="slate"] {
    --drawio-color-ffffff: #ffffff;
    --drawio-color-f5f5f5: #f5f5f5;
    --drawio-color-dae8fc: #dae8fc;
    --drawio-color-d5e8d4: #d5e8d4;
    --drawio-color-ffe6cc: #ffe6cc;
    --drawio-color-fff2cc: #fff2cc;
    --drawio-color-f8cecc: #f8cecc;
    --drawio-color-e1d5e7: #e1d5e7;
}
```

And the `index.md`:

```md
# Test

![](test.drawio)
```

Another option to add is to let the user choose which drawing requires local CSS. We could imagine later using `attr_list`

```md
![](test.drawio)
![](test.drawio){link_css=true}
```